### PR TITLE
Implement Ioctx createReadStream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,22 @@
+var rados = require('bindings')('rados');
+
+var ReadableStream = require('stream').Readable;
+
+rados.Ioctx.prototype.createReadStream = function(oid, options) {
+  var ioctx = this;
+
+  var stream = new ReadableStream(options);
+  stream._offset = 0;
+
+  stream._read = function(size) {
+    ioctx.aio_read(oid, size, stream._offset, function(err, chunk) {
+      if (err) return stream.emit('error', err);
+      stream._offset += chunk.length;
+      stream.push((chunk.length > 0) ? chunk : null);
+    });
+  };
+
+  return stream;
+}
+
+exports = module.exports = rados;

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
 	"version": "0.2.8",
 	"description" : "Ceph rados client for node.js",
 	"author" : "Laurent Barbe <laurent@ksperis.com>",
-	"main": "./build/Release/rados",
  	"repository" : {
 		"type" : "git",
 		"url" : "git://github.com/ksperis/node-rados.git"
 	},
 	"dependencies" : {
+		"bindings": "*",
 		"nan": "*",
 		"node-gyp": ">0.10.0"
 	},

--- a/test/rados.js
+++ b/test/rados.js
@@ -1,4 +1,4 @@
-var rados = require('../build/Release/rados');
+var rados = require('../');
 
 var CEPH_CLUSTER = 'ceph';
 var CEPH_ID = 'client.admin';


### PR DESCRIPTION
This patch also makes use of index.js. I think we should look at moving more stuff out of the native module and into index.js instead. We should try to make the native module as simple as possible and rely on pure javascript for doing trivial stuffs. Ex. the recent connection state checking could potentially have been implemented inside index.js, or in the future for implementing turning Rados errno codes into error objects.